### PR TITLE
Summarize all trade ledger gauntlet setups

### DIFF
--- a/alpha_discovery/gauntlet/reporting.py
+++ b/alpha_discovery/gauntlet/reporting.py
@@ -144,6 +144,8 @@ def write_readme(run_dir: str, extra: Optional[dict] = None) -> str:
         "  - stage2_mbb_pvalues.csv      : Moving Block Bootstrap p-values and block lengths.",
         "  - stage3_fdr_dsr.csv          : Benjamini–Hochberg FDR and Deflated Sharpe across the cohort.",
         "  - gauntlet_ledger.csv         : Full OOS trade ledger (forward-compatible schema).",
+        "  - all_setups_gauntlet_summary.csv : Summary of ALL setups that entered the gauntlet (regardless of pass/fail).",
+        "  - gauntlet_summary.csv        : Summary of setups that PASSED all gauntlet stages.",
         "",
         "Notes:",
         "  * Stage-1 uses short/medium/long EWMAs and a live-trigger gate.",


### PR DESCRIPTION
Add a new summary file (`all_setups_gauntlet_summary.csv`) to report on all setups processed by the gauntlet, including those that failed at any stage.

---
<a href="https://cursor.com/background-agent?bcId=bc-15d8a3a8-1573-4756-a4d5-70e597d700ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15d8a3a8-1573-4756-a4d5-70e597d700ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

